### PR TITLE
TASK: Introduce a new interface to customize de default TS prototype

### DIFF
--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/DefaultPrototypeGenerator.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/DefaultPrototypeGenerator.php
@@ -1,0 +1,67 @@
+<?php
+namespace TYPO3\Neos\Domain\Service;
+
+/*
+ * This file is part of the TYPO3.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\TYPO3CR\Domain\Model\NodeType;
+
+/**
+ * Generate a TypoScript prototype definition for a given node type
+ *
+ * @Flow\Scope("singleton")
+ * @api
+ */
+class DefaultPrototypeGenerator implements DefaultPrototypeGeneratorInterface
+{
+    /**
+     * Generate a TypoScript prototype definition for a given node type
+     *
+     * A node will be rendered by TYPO3.Neos:Content by default with a template in
+     * resource://PACKAGE_KEY/Private/Templates/NodeTypes/NAME.html and forwards all public
+     * node properties to the template TypoScript object.
+     *
+     * @param NodeType $nodeType
+     * @return string
+     */
+    public function generate(NodeType $nodeType)
+    {
+        if (strpos($nodeType->getName(), ':') === false) {
+            return '';
+        }
+
+        if ($nodeType->isOfType('TYPO3.Neos:Content')) {
+            $basePrototypeName = 'TYPO3.Neos:Content';
+        } elseif ($nodeType->isOfType('TYPO3.Neos:Document')) {
+            $basePrototypeName = 'TYPO3.Neos:Document';
+        } else {
+            $basePrototypeName = 'TYPO3.TypoScript:Template';
+        }
+
+        $output = 'prototype(' . $nodeType->getName() . ') < prototype(' . $basePrototypeName . ') {' . chr(10);
+
+        list($packageKey, $relativeName) = explode(':', $nodeType->getName(), 2);
+        $templatePath = 'resource://' . $packageKey . '/Private/Templates/NodeTypes/' . $relativeName . '.html';
+        $output .= "\t" . 'templatePath = \'' . $templatePath . '\'' . chr(10);
+
+        foreach ($nodeType->getProperties() as $propertyName => $propertyConfiguration) {
+            if (isset($propertyName[0]) && $propertyName[0] !== '_') {
+                $output .= "\t" . $propertyName . ' = ${q(node).property("' . $propertyName . '")}' . chr(10);
+                if (isset($propertyConfiguration['type']) && isset($propertyConfiguration['ui']['inlineEditable']) && $propertyConfiguration['type'] === 'string' && $propertyConfiguration['ui']['inlineEditable'] === true) {
+                    $output .= "\t" . $propertyName . '.@process.convertUris = TYPO3.Neos:ConvertUris' . chr(10);
+                }
+            }
+        }
+
+        $output .= '}' . chr(10);
+        return $output;
+    }
+}

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/DefaultPrototypeGeneratorInterface.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/DefaultPrototypeGeneratorInterface.php
@@ -1,0 +1,34 @@
+<?php
+namespace TYPO3\Neos\Domain\Service;
+
+/*
+ * This file is part of the TYPO3.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use TYPO3\TYPO3CR\Domain\Model\NodeType;
+
+/**
+ * Generate a TypoScript prototype definition for a given node type
+ *
+ * @api
+ */
+interface DefaultPrototypeGeneratorInterface
+{
+    /**
+     * Generate a TypoScript prototype definition for a given node type
+     *
+     * A node will be rendered by TYPO3.Neos:Content by default with a template in
+     * resource://PACKAGE_KEY/Private/Templates/NodeTypes/NAME.html and forwards all public
+     * node properties to the template TypoScript object.
+     *
+     * @param NodeType $nodeType
+     * @return string
+     */
+    public function generate(NodeType $nodeType);
+}

--- a/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/TypoScriptService.php
+++ b/TYPO3.Neos/Classes/TYPO3/Neos/Domain/Service/TypoScriptService.php
@@ -31,6 +31,12 @@ class TypoScriptService
     protected $typoScriptParser;
 
     /**
+     * @Flow\Inject
+     * @var DefaultPrototypeGeneratorInterface
+     */
+    protected $defaultPrototypeGenerator;
+
+    /**
      * Pattern used for determining the TypoScript root file for a site
      *
      * @var string
@@ -193,35 +199,7 @@ class TypoScriptService
      */
     protected function generateTypoScriptForNodeType(NodeType $nodeType)
     {
-        if (strpos($nodeType->getName(), ':') === false) {
-            return '';
-        }
-
-        if ($nodeType->isOfType('TYPO3.Neos:Content')) {
-            $basePrototypeName = 'TYPO3.Neos:Content';
-        } elseif ($nodeType->isOfType('TYPO3.Neos:Document')) {
-            $basePrototypeName = 'TYPO3.Neos:Document';
-        } else {
-            $basePrototypeName = 'TYPO3.TypoScript:Template';
-        }
-
-        $output = 'prototype(' . $nodeType->getName() . ') < prototype(' . $basePrototypeName . ') {' . chr(10);
-
-        list($packageKey, $relativeName) = explode(':', $nodeType->getName(), 2);
-        $templatePath = 'resource://' . $packageKey . '/Private/Templates/NodeTypes/' . $relativeName . '.html';
-        $output .= "\t" . 'templatePath = \'' . $templatePath . '\'' . chr(10);
-
-        foreach ($nodeType->getProperties() as $propertyName => $propertyConfiguration) {
-            if (isset($propertyName[0]) && $propertyName[0] !== '_') {
-                $output .= "\t" . $propertyName . ' = ${q(node).property("' . $propertyName . '")}' . chr(10);
-                if (isset($propertyConfiguration['type']) && isset($propertyConfiguration['ui']['inlineEditable']) && $propertyConfiguration['type'] === 'string' && $propertyConfiguration['ui']['inlineEditable'] === true) {
-                    $output .= "\t" . $propertyName . '.@process.convertUris = TYPO3.Neos:ConvertUris' . chr(10);
-                }
-            }
-        }
-
-        $output .= '}' . chr(10);
-        return $output;
+        return $this->defaultPrototypeGenerator->generate($nodeType);
     }
 
     /**


### PR DESCRIPTION
This change introduce a new interface `DefaultPrototypeGeneratorInterface`.
By implementing this interface you can change the default TypoScript prototype
generate by Neos for every NodeType.
